### PR TITLE
Fix JS error when previewing report in card editor

### DIFF
--- a/arches_modular_reports/media/js/reports/modular-report.js
+++ b/arches_modular_reports/media/js/reports/modular-report.js
@@ -166,7 +166,7 @@ ko.components.register('modular-report', {
             const graphSlug = params.report.graph?.slug || params.report.report_json.graph_slug;
 
             vueApp.provide("graphSlug", graphSlug);
-            vueApp.provide('resourceInstanceId', params.report.report_json.resourceinstanceid);
+            vueApp.provide("resourceInstanceId", params.report?.report_json?.resourceinstanceid);
             vueApp.mount(mountingPoint);
         });
     },


### PR DESCRIPTION
- Preview the report from the card error: notice a JS error

Now, the report is blank, but at least it doesn't prevent bootstrapping the vue app.