### PR TITLE
Better `ModularReport` encapsulation 

### DIFF
--- a/arches_modular_reports/media/js/reports/modular-report.js
+++ b/arches_modular_reports/media/js/reports/modular-report.js
@@ -152,7 +152,11 @@ const ModularReportTheme = {
 
 ko.components.register('modular-report', {
     viewModel: function(params) {
-        createVueApplication(ModularReport, ModularReportTheme).then(vueApp => {
+
+        const graphSlug = params.report.graph?.slug || params.report.report_json.graph_slug;
+        const resourceInstanceId = params.report.report_json.resourceinstanceid;
+
+        createVueApplication(ModularReport, ModularReportTheme, { graphSlug, resourceInstanceId }).then(vueApp => {
             // handles the Graph Designer case of multiple mounting points on the same page
             const mountingPoints = document.querySelectorAll('.modular-report-mounting-point');
             const mountingPoint = mountingPoints[mountingPoints.length - 1];
@@ -163,10 +167,6 @@ ko.components.register('modular-report', {
             }
             window.archesModularReportVueApp = vueApp;
 
-            const graphSlug = params.report.graph?.slug || params.report.report_json.graph_slug;
-
-            vueApp.provide("graphSlug", graphSlug);
-            vueApp.provide('resourceInstanceId', params.report.report_json.resourceinstanceid);
             vueApp.mount(mountingPoint);
         });
     },

--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/ModularReport.vue
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/ModularReport.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, watchEffect, provide, ref, isRef } from "vue";
+import { computed, watchEffect, provide, ref } from "vue";
 import { useGettext } from "vue3-gettext";
 
 import Panel from "primevue/panel";
@@ -29,7 +29,14 @@ const toast = useToast();
 const { $gettext } = useGettext();
 const componentLookup: ComponentLookup = {};
 
-let resourceInstanceId = inject<string | Ref<string>>("resourceInstanceId");
+const { graphSlug, resourceInstanceId } = defineProps<{
+    graphSlug: string;
+    resourceInstanceId: string;
+}>();
+
+provide("graphSlug", graphSlug);
+provide("resourceInstanceId", resourceInstanceId);
+
 const nodePresentationLookup: Ref<NodePresentationLookup | undefined> = ref();
 provide("nodePresentationLookup", nodePresentationLookup);
 
@@ -66,22 +73,15 @@ const gutterVisibility = computed(() => {
 });
 
 watchEffect(async () => {
-    if (!isRef(resourceInstanceId)) {
-        // If resourceInstanceId is a ref, we need to access its value
-        resourceInstanceId = ref(resourceInstanceId);
-    }
-    if (!resourceInstanceId.value) {
-        return;
-    }
     try {
         await Promise.all([
-            fetchNodePresentation(resourceInstanceId.value).then((data) => {
+            fetchNodePresentation(resourceInstanceId).then((data) => {
                 nodePresentationLookup.value = data;
             }),
-            fetchUserResourcePermissions(resourceInstanceId.value).then((data) => {
+            fetchUserResourcePermissions(resourceInstanceId).then((data) => {
                 userCanEditResourceInstance.value = data.edit;
             }),
-            fetchReportConfig(resourceInstanceId.value).then((data) => {
+            fetchReportConfig(resourceInstanceId).then((data) => {
                 importComponents([data], componentLookup);
                 config.value = data;
             }),

--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/components/ResourceEditor/components/CardEditor/CardEditor.vue
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/components/ResourceEditor/components/CardEditor/CardEditor.vue
@@ -3,7 +3,10 @@ import { inject } from "vue";
 
 import DefaultCard from "@/arches_component_lab/cards/DefaultCard/DefaultCard.vue";
 
-const graphSlug = inject<string>("graphSlug")!;
+import { EDIT } from "@/arches_component_lab/widgets/constants.ts";
+
+const graphSlug = inject<string>("graphSlug");
+const resourceInstanceId = inject<string>("resourceInstanceId");
 
 const { selectedNodegroupAlias } = inject("selectedNodegroupAlias") as {
     selectedNodegroupAlias: string | null;
@@ -16,11 +19,14 @@ const { selectedTileId } = inject("selectedTileId") as {
 <template>
     <DefaultCard
         v-if="selectedNodegroupAlias && graphSlug"
-        mode="edit"
+        :mode="EDIT"
         :nodegroup-alias="selectedNodegroupAlias"
         :graph-slug="graphSlug"
+        :resource-instance-id="resourceInstanceId"
         :tile-id="selectedTileId"
-        @update:is-dirty="console.log('update:isDirty', $event)"
+        @update:widget-dirty-states="
+            console.log('update:widgetDirtyStates', $event)
+        "
         @update:tile-data="console.log('update:tileData', $event)"
     />
 </template>


### PR DESCRIPTION
sister ticket to: https://github.com/archesproject/arches-component-lab/pull/98
relies on: https://github.com/archesproject/arches/pull/12316


Updates `ModularReport` to not rely on external `provide`s. This should make using the component outside of the Arches Report easier