### PR TITLE
Don't exclude geo and annotation nodes from presentation lookup

### DIFF
--- a/arches_modular_reports/app/views/modular_report.py
+++ b/arches_modular_reports/app/views/modular_report.py
@@ -237,7 +237,6 @@ class NodePresentationView(APIBase):
         nodes = (
             models.Node.objects.filter(graph=graph)
             .filter(nodegroup__in=permitted_nodegroups)
-            .exclude(datatype__in={"annotation", "geojson-feature-collection"})
             .select_related("nodegroup")
             .prefetch_related(
                 "nodegroup__cardmodel_set",


### PR DESCRIPTION
Hypothetical fix for issue in RasColls.

Once we reused the node/widget/card information powering the graph to also power the report editor, I forgot that some nodes were excluded. Let's just add them back so that we don't null guard in random places. The data tree for the resource editor includes all nodes at the moment.