### PR TITLE
Expand selected tile or new card in tree #27

### DIFF
--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/components/DataSection.vue
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/components/DataSection.vue
@@ -62,10 +62,10 @@ const nodePresentationLookup = inject("nodePresentationLookup") as Ref<
     NodePresentationLookup | undefined
 >;
 const { setSelectedNodegroupAlias } = inject("selectedNodegroupAlias") as {
-    setSelectedNodegroupAlias: (nodegroupAlias: string | null) => void;
+    setSelectedNodegroupAlias: (nodegroupAlias: string | undefined) => void;
 };
 const { setSelectedTileId } = inject("selectedTileId") as {
-    setSelectedTileId: (tileId: string | null) => void;
+    setSelectedTileId: (tileId: string | null | undefined) => void;
 };
 
 const first = computed(() => {

--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/utils.ts
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/utils.ts
@@ -1,5 +1,6 @@
 import { defineAsyncComponent } from "vue";
 
+import type { TreeNode } from "primevue/treenode";
 import type {
     ComponentLookup,
     NamedSection,
@@ -48,4 +49,41 @@ export function truncateDisplayData(
         }
         return acc;
     }, [] as NodeValueDisplayData[]);
+}
+
+// a riff on the version from arches-controlled-lists using different attributes
+export function findNodeInTree(
+    tree: TreeNode[],
+    tileId: string | null,
+    nodegroupAlias: string | undefined,
+) {
+    const path: TreeNode[] = [];
+
+    function recurse(items: TreeNode[]): TreeNode | undefined {
+        for (const item of items) {
+            if (tileId && item.data.tileid === tileId) {
+                return item;
+            }
+            if (!tileId && item.data.alias === nodegroupAlias) {
+                // Wrapper nodes for top cards
+                return item;
+            }
+            if (item.children) {
+                for (const child of item.children) {
+                    const found = recurse([child]);
+                    if (found) {
+                        path.push(item);
+                        return found;
+                    }
+                }
+            }
+        }
+    }
+
+    const found = recurse(tree);
+    if (!found) {
+        throw new Error();
+    }
+
+    return { found, path };
 }


### PR DESCRIPTION
Closes #27 

A slight weirdness that I decided to leave as-is for the time being is when interacting with the carets to manually expand other nodegroups, and clicking a node inside a different card. The selected node becomes the card, not the node. Reclicking the node selects the node. We can discuss -- would be a bit of a fix to make data tree nodes aware of their nodegroup aliases.