### PR TITLE
Edit nested cards #64

### DIFF
--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/components/ResourceEditor/ResourceEditor.vue
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/components/ResourceEditor/ResourceEditor.vue
@@ -8,16 +8,16 @@ import DataTree from "@/arches_modular_reports/ModularReport/components/Resource
 import GenericCard from "@/arches_component_lab/generics/GenericCard/GenericCard.vue";
 
 import { fetchModularReportResource } from "@/arches_modular_reports/ModularReport/api.ts";
+import { findTileInTileTree } from "@/arches_modular_reports/ModularReport/utils.ts";
 
 import { EDIT } from "@/arches_component_lab/widgets/constants.ts";
 
 import type { Ref } from "vue";
 import type {
-    NodeData,
-    NodegroupData,
     ResourceData,
     TileData,
 } from "@/arches_modular_reports/ModularReport/types.ts";
+import type { AliasedTileData } from "@/arches_component_lab/types";
 
 const { selectedNodegroupAlias } = inject("selectedNodegroupAlias") as {
     selectedNodegroupAlias: Ref<string | null>;
@@ -53,34 +53,21 @@ watchEffect(async () => {
 });
 
 const selectedTileData = computed<TileData | undefined>(() => {
-    const selectedNodegroupAliasedTileData: NodeData | NodegroupData =
-        resourceData.aliased_data[selectedNodegroupAlias.value!];
-
-    if (Array.isArray(selectedNodegroupAliasedTileData)) {
-        return selectedNodegroupAliasedTileData.find(
-            (tileDatum) => tileDatum.tileid === selectedTileId.value,
-        );
+    if (selectedTileId.value) {
+        return findTileInTileTree(resourceData, selectedTileId.value);
     }
-    return selectedNodegroupAliasedTileData as TileData;
+    return undefined;
 });
 
 function onUpdateTileData(updatedTileData: TileData) {
-    const selectedNodegroupAliasedTileData: NodeData | NodegroupData =
-        resourceData.aliased_data[selectedNodegroupAlias.value!];
-
-    if (Array.isArray(selectedNodegroupAliasedTileData)) {
-        const selectedTileDatum = selectedNodegroupAliasedTileData.find(
-            (tileDatum) => tileDatum.tileid === selectedTileId.value,
+    if (selectedTileId.value) {
+        const selectedTileDatum = findTileInTileTree(
+            resourceData,
+            selectedTileId.value,
         );
-
-        if (selectedTileDatum) {
-            Object.assign(selectedTileDatum, updatedTileData);
-        }
+        Object.assign(selectedTileDatum, updatedTileData);
     } else {
-        Object.assign(
-            selectedNodegroupAliasedTileData as TileData,
-            updatedTileData,
-        );
+        throw new Error("Missing tile id for update");
     }
 }
 </script>
@@ -105,7 +92,7 @@ function onUpdateTileData(updatedTileData: TileData) {
             :graph-slug="graphSlug"
             :resource-instance-id="resourceInstanceId"
             :tile-id="selectedTileId"
-            :tile-data="selectedTileData"
+            :tile-data="selectedTileData as unknown as AliasedTileData"
             @save="
                 console.log('save', $event);
                 emit('save', $event);

--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/types.ts
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/types.ts
@@ -1,9 +1,6 @@
 import type { Component } from "vue";
 
-import type {
-    AliasedNodeData,
-    AliasedNodegroupData,
-} from "@/arches_component_lab/types.ts";
+import type { AliasedNodeData } from "@/arches_component_lab/types.ts";
 
 export interface Settings {
     ACTIVE_LANGUAGE: string;
@@ -91,11 +88,11 @@ export interface NodeData {
 export type NodegroupData = TileData | TileData[] | null;
 
 export interface AliasedData {
-    [key: string]: AliasedNodeData | AliasedNodegroupData;
+    [key: string]: AliasedNodeData | NodegroupData;
 }
 
 export interface TileData {
-    aliased_data: AliasedData;
+    aliased_data: TileData | TileData[]; // could be NodegroupData if fillBlanks=false
     nodegroup: string;
     parenttile: string | null;
     provisionaledits: object | null;
@@ -105,7 +102,7 @@ export interface TileData {
 }
 
 export interface ResourceData {
-    aliased_data: AliasedData;
+    aliased_data: TileData | TileData[]; // could be NodegroupData if fillBlanks=false
     resourceinstanceid?: string;
     name?: string;
     descriptors?: {

--- a/arches_modular_reports/src/arches_modular_reports/ModularReport/utils.ts
+++ b/arches_modular_reports/src/arches_modular_reports/ModularReport/utils.ts
@@ -6,6 +6,8 @@ import type {
     NamedSection,
     NodeValueDisplayData,
     SectionContent,
+    ResourceData,
+    TileData,
 } from "@/arches_modular_reports/ModularReport/types";
 
 export function uniqueId(_unused: unknown) {
@@ -86,4 +88,39 @@ export function findNodeInTree(
     }
 
     return { found, path };
+}
+
+export function findTileInTileTree(
+    resourceOrTileData: ResourceData | TileData,
+    tileId: string,
+) {
+    function traverse(
+        resourceOrTileData: ResourceData | TileData,
+    ): TileData | undefined {
+        if ((resourceOrTileData as TileData).tileid === tileId) {
+            return resourceOrTileData as TileData;
+        }
+        for (const data of Object.values(resourceOrTileData.aliased_data)) {
+            let found;
+            if (Array.isArray(data)) {
+                for (const tileData of data) {
+                    found = traverse(tileData);
+                    if (found) {
+                        return found;
+                    }
+                }
+            } else if (data.aliased_data) {
+                found = traverse(data);
+                if (found) {
+                    return found;
+                }
+            }
+        }
+    }
+
+    const found = traverse(resourceOrTileData);
+    if (!found) {
+        throw new Error();
+    }
+    return found;
 }


### PR DESCRIPTION
Previously, the derived state and on update behavior for card updates only checked top tiles.

Now, we descend into the tree.

Some follow-up work will be needed for allowing blank parent tiles to be generated on the backend where necessary.

Closes #64