### PR TITLE
report configs without a config name ordered by first in return

### DIFF
--- a/arches_modular_reports/app/views/modular_report.py
+++ b/arches_modular_reports/app/views/modular_report.py
@@ -55,6 +55,7 @@ class ModularReportConfigView(View):
             ReportConfig.objects.filter(filters)
             .select_related("graph")
             .prefetch_related("graph__node_set", "graph__node_set__nodegroup")
+            .order_by("config__name__desc")
             .first()
         )
 


### PR DESCRIPTION
if no config name, order by first in the return of report configs - otherwise multiple (named) report configs can be breaking functionality.  