### PR TITLE
Not format date display value in db, arches#12480

### DIFF
--- a/arches_modular_reports/migrations/0004_handle_for_concept_label_subregions.py
+++ b/arches_modular_reports/migrations/0004_handle_for_concept_label_subregions.py
@@ -435,8 +435,6 @@ class Migration(migrations.Migration):
                                 display_value := __arches_get_resourceinstance_label(in_tiledata -> in_nodeid::text, 'name', language_id);
                             when 'resource-instance-list' then
                                 display_value := __arches_get_resourceinstance_list_label_v2(in_tiledata -> in_nodeid::text, 'name', language_id);
-                            when 'date' then
-                                display_value := TO_CHAR((in_tiledata ->> in_nodeid::text)::timestamp, in_node_config ->> 'dateFormat');
                             else
                                 display_value := (in_tiledata ->> in_nodeid::text)::text;
 


### PR DESCRIPTION
The db function to format display value for the date datatype is removed based on the core ticket.

https://github.com/archesproject/arches/issues/12480

No longer need to format the tiledata, when the above ticket is fixed and merged.