### PR TITLE
allow reports to select the config based on report config slug

### DIFF
--- a/arches_modular_reports/media/js/reports/modular-report.js
+++ b/arches_modular_reports/media/js/reports/modular-report.js
@@ -131,6 +131,7 @@ ko.components.register('modular-report', {
 
         let graphSlug = params.report.graph?.slug || params.report.report_json.graph_slug;
         const resourceInstanceId = params.report.report_json.resourceinstanceid;
+        const reportConfigSlug = params.report.report_json.report_config_slug;
 
         if (!graphSlug) {
             // fetch graph slug from graph id this can happen when viewing the 
@@ -140,7 +141,7 @@ ko.components.register('modular-report', {
             graphSlug = data.graph_slug;
         }
 
-        createVueApplication(ModularReport, ModularReportTheme, { graphSlug, resourceInstanceId }).then(vueApp => {
+        createVueApplication(ModularReport, ModularReportTheme, { graphSlug, resourceInstanceId, reportConfigSlug }).then(vueApp => {
             // handles the Graph Designer case of multiple mounting points on the same page
             const mountingPoints = document.querySelectorAll('.modular-report-mounting-point');
             const mountingPoint = mountingPoints[mountingPoints.length - 1];

--- a/arches_modular_reports/templates/views/resource/modular_report.htm
+++ b/arches_modular_reports/templates/views/resource/modular_report.htm
@@ -19,6 +19,7 @@
                     report_json: {
                         graph_slug: '{{ graph_slug }}',
                         resourceinstanceid: '{{ resourceid }}',
+                        report_config_slug: '{{ report_config_slug }}',
                     },
                 },
                 disableDisambiguatedReport: true,

--- a/arches_modular_reports/urls.py
+++ b/arches_modular_reports/urls.py
@@ -24,8 +24,8 @@ urlpatterns = [
     ),
     # Override core arches resource report view to allow rendering
     # distinct template for modular reports.
-    re_path(
-        r"^report/(?P<resourceid>%s)$" % uuid_regex,
+    path(
+        "report/<uuid:resourceid>/<str:report_config_slug>",
         ModularReportAwareResourceReportView.as_view(),
         name="resource_report",
     ),


### PR DESCRIPTION
You can now add the report config slug to the end of the report url to pick up that specific config.
EG: localhost:8000/report/{uuid}/{report_config_slug}